### PR TITLE
docs: document library name change and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: Library name changed from `marisa` to `rsmarisa` to align with package name
+  - Users must update imports from `use marisa::` to `use rsmarisa::`
+  - Eliminates confusion where package name (`rsmarisa`) didn't match import path (`marisa`)
+  - Improves discoverability and follows Rust naming conventions
+  - All source files, tests, examples, and documentation updated
+
 ## [0.1.0] - 2026-01-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,14 +428,18 @@ The tagpr configuration is in `.tagpr`:
   - `rsmarisa-dump` - Dictionary dumper
 - **Integration tests**: CLI tools verified against C++ counterparts
 - **Memory safety**: Fixed all use-after-free bugs in reverse_lookup and predictive_search
-- **Published to crates.io**: Version 0.1.0 available at https://crates.io/crates/rsmarisa
+- **Published to crates.io**: Version 0.2.0 available at https://crates.io/crates/rsmarisa
 - **Automated releases**: Using tagpr for release management and GitHub Actions for CI/CD
-- **Memory-mapped I/O**: Full implementation using memmap2
+- **Memory-mapped I/O**: Full implementation using memmap2 (v0.2.0)
   - `Trie::mmap(filename)` - Load from file-backed memory map
   - `Trie::map(data)` - Load from static memory
   - Binary compatible with C++-created dictionaries
   - All vector types support map() operation
   - Proper lifetime management to prevent dangling pointers
+- **Library name alignment**: Changed library name from `marisa` to `rsmarisa` (v0.3.0, merged in PR #8)
+  - Eliminates confusion between package name and import path
+  - Users now write `rsmarisa = "0.3"` in Cargo.toml and `use rsmarisa::` in code
+  - Breaking change requiring update of all imports
 
 ### 📝 Known Issues
 - Numerous compiler warnings (mostly lifetime annotations) - non-critical
@@ -554,3 +558,18 @@ Testing against the original C++ implementation is invaluable:
 - Ensures true compatibility
 - Provides confidence in correctness
 - Documents expected behavior
+
+### 4. Library Name Consistency
+**Problem**: Originally, the package name was `rsmarisa` but the library name was `marisa`. This created confusion where users would write `rsmarisa = "0.2"` in their `Cargo.toml` but then use `use marisa::` in their code.
+
+**Solution**: Align the library name with the package name by changing `[lib] name = "marisa"` to `name = "rsmarisa"` in `Cargo.toml`.
+
+**Why this matters**:
+- **User experience**: The import path should match what users specify in their dependencies
+- **Discoverability**: When searching for "rsmarisa", the import path should be obvious
+- **Convention**: Most Rust crates use the same name for package and library
+- **Documentation clarity**: Examples and docs become more consistent
+
+**Impact**: This is a breaking change requiring all users to update their imports from `use marisa::` to `use rsmarisa::`. However, it significantly improves the long-term developer experience.
+
+**Files affected**: All source files, tests, examples, and documentation that import the library.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ cargo run --example save_load
 - ✅ **Static memory support**: `Trie::map()` for embedding dictionary data in binaries
 - ✅ **Binary compatibility**: Both `mmap()` and `load()` work with C++-created files
 
+**Upcoming in v0.3.0 (Breaking Change):**
+- 🔄 **Library name alignment**: The library name has been changed from `marisa` to `rsmarisa` to match the package name
+  - **Migration required**: Update all imports from `use marisa::` to `use rsmarisa::`
+  - **Why**: Eliminates confusion and aligns with Rust naming conventions
+  - **Impact**: All users must update their code when upgrading to v0.3.0
+
 See [CHANGELOG.md](CHANGELOG.md) for complete version history.
 
 ### What's Implemented


### PR DESCRIPTION
## Summary

This PR adds documentation for the library name change from `marisa` to `rsmarisa` that was implemented in PR #8.

## Changes

- **README.md**: Added "Upcoming in v0.3.0" section highlighting the breaking change
- **CLAUDE.md**: 
  - Updated project status to reflect v0.2.0 and the library name change
  - Added new "Library Name Consistency" section to Key Lessons Learned
- **CHANGELOG.md**: Added breaking change entry to Unreleased section

## Rationale

Since PR #8 introduced a breaking change (library name alignment), users need clear documentation about:
- What changed and why
- Migration steps required
- Impact on existing code

This documentation will help users understand and prepare for the v0.3.0 upgrade.

## Related

- PR #8: fix: align library name with package name (marisa -> rsmarisa)