### PR TITLE
fix: remove unnecessary .to_vec() heap copies in search operations

### DIFF
--- a/src/grimoire/trie/louds_trie.rs
+++ b/src/grimoire/trie/louds_trie.rs
@@ -1191,8 +1191,7 @@ impl LoudsTrie {
         assert!(query_pos < query_len, "Query position out of bounds");
 
         let node_id = state.node_id();
-        let query_bytes = agent.query().as_bytes().to_vec();
-        let query_char = query_bytes[query_pos];
+        let query_char = agent.query().as_bytes()[query_pos];
 
         // Check cache first
         let cache_id = self.get_cache_id_with_label(node_id, query_char);
@@ -1518,8 +1517,7 @@ impl LoudsTrie {
         assert!(query_pos < query_len, "Query position out of bounds");
 
         let node_id = state.node_id();
-        let query_bytes = agent.query().as_bytes().to_vec();
-        let query_char = query_bytes[query_pos];
+        let query_char = agent.query().as_bytes()[query_pos];
 
         // Check cache first
         let cache_id = self.get_cache_id_with_label(node_id, query_char);
@@ -1729,8 +1727,6 @@ impl LoudsTrie {
         let query_len = agent.query().length();
         let mut query_pos = agent.state().expect("Agent must have state").query_pos();
 
-        let query_bytes = agent.query().as_bytes().to_vec();
-
         assert!(query_pos < query_len, "Query position out of bounds");
         assert!(node_id != 0, "Node ID must not be 0");
 
@@ -1746,7 +1742,7 @@ impl LoudsTrie {
                     }
                     // Re-sync local query_pos after match_link may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
-                } else if self.cache[cache_id].label() == query_bytes[query_pos] {
+                } else if self.cache[cache_id].label() == agent.query().as_bytes()[query_pos] {
                     query_pos += 1;
                     agent
                         .state_mut()
@@ -1779,7 +1775,7 @@ impl LoudsTrie {
                     // Re-sync local query_pos after tail.match_tail may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
                 }
-            } else if self.bases[node_id] == query_bytes[query_pos] {
+            } else if self.bases[node_id] == agent.query().as_bytes()[query_pos] {
                 query_pos += 1;
                 agent
                     .state_mut()
@@ -1806,8 +1802,6 @@ impl LoudsTrie {
 
         assert!(query_pos < query_len, "Query position out of bounds");
         assert!(node_id != 0, "Node ID must not be 0");
-
-        let query_bytes = agent.query().as_bytes().to_vec();
         let mut node_id = node_id;
 
         loop {
@@ -1820,7 +1814,7 @@ impl LoudsTrie {
                     }
                     // Re-sync local query_pos after prefix_match may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
-                } else if self.cache[cache_id].label() == query_bytes[query_pos] {
+                } else if self.cache[cache_id].label() == agent.query().as_bytes()[query_pos] {
                     agent
                         .state_mut()
                         .expect("Agent must have state")
@@ -1846,7 +1840,7 @@ impl LoudsTrie {
                     }
                     // Re-sync local query_pos after prefix_match may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
-                } else if self.bases[node_id] == query_bytes[query_pos] {
+                } else if self.bases[node_id] == agent.query().as_bytes()[query_pos] {
                     agent
                         .state_mut()
                         .expect("Agent must have state")


### PR DESCRIPTION
## Summary

- Remove `.to_vec()` heap allocations from `find_child`, `predictive_find_child`, `match_`, and `prefix_match_` in `LoudsTrie`
- Query bytes are now read directly via `agent.query().as_bytes()[pos]` instead of copying the entire byte slice to a new `Vec` on every call
- The query is immutable during search, so borrowing is safe and sufficient

## Context

Profiling showed ~25% of total execution time was spent on malloc/free/Vec grow caused by these unnecessary heap copies (see #10).

| Category | Self % |
|----------|--------|
| malloc + cfree + _int_free | ~17% |
| Vec grow (RawVecInner + reserve) | ~8.5% |

## Test plan

- [x] All 321 unit tests pass
- [x] No new unsafe code introduced
- [x] Binary compatibility unchanged (read-only change to search path)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)