### PR TITLE
feat(io): allow Reader to accept non-'static Read implementations

### DIFF
--- a/src/grimoire/io/reader.rs
+++ b/src/grimoire/io/reader.rs
@@ -15,12 +15,12 @@ use std::path::Path;
 ///
 /// Reader wraps a std::io::Read implementation and provides convenient
 /// methods for reading typed data and seeking forward.
-pub struct Reader {
+pub struct Reader<'a> {
     /// The underlying reader, boxed for trait object support.
-    reader: Option<Box<dyn IoRead>>,
+    reader: Option<Box<dyn IoRead + 'a>>,
 }
 
-impl Reader {
+impl<'a> Reader<'a> {
     /// Creates a new empty reader.
     pub fn new() -> Self {
         Reader { reader: None }
@@ -35,7 +35,7 @@ impl Reader {
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened.
-    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Reader<'static>> {
         let file = File::open(path)?;
         Ok(Reader {
             reader: Some(Box::new(file)),
@@ -47,7 +47,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `reader` - Any type implementing Read
-    pub fn from_reader<R: IoRead + 'static>(reader: R) -> Self {
+    pub fn from_reader<R: IoRead + 'a>(reader: R) -> Self {
         Reader {
             reader: Some(Box::new(reader)),
         }
@@ -58,7 +58,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `bytes` - Byte slice to read from
-    pub fn from_bytes(bytes: &[u8]) -> Self {
+    pub fn from_bytes(bytes: &[u8]) -> Reader<'static> {
         Reader {
             reader: Some(Box::new(io::Cursor::new(bytes.to_vec()))),
         }
@@ -199,7 +199,7 @@ impl Reader {
     }
 }
 
-impl Default for Reader {
+impl<'a> Default for Reader<'a> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/grimoire/trie/header.rs
+++ b/src/grimoire/trie/header.rs
@@ -82,7 +82,7 @@ impl Header {
     /// # Errors
     ///
     /// Returns an error if the header is invalid or reading fails
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         let mut buf = [0u8; HEADER_SIZE];
         reader.read_slice(&mut buf)?;
 

--- a/src/grimoire/trie/louds_trie.rs
+++ b/src/grimoire/trie/louds_trie.rs
@@ -936,7 +936,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if reading fails or header is invalid
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         use crate::grimoire::trie::header::Header;
         Header::new().read(reader)?;
         self.read_internal(reader)
@@ -978,7 +978,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if reading fails
-    fn read_internal(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    fn read_internal(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         // Read all component data structures
         self.louds.read(reader)?;
         self.terminal_flags.read(reader)?;

--- a/src/grimoire/trie/tail.rs
+++ b/src/grimoire/trie/tail.rs
@@ -258,7 +258,7 @@ impl Tail {
     /// # Errors
     ///
     /// Returns an error if reading fails.
-    pub fn read(&mut self, reader: &mut Reader) -> io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> io::Result<()> {
         self.buf.read(reader)?;
         self.end_flags.read(reader)?;
         Ok(())

--- a/src/grimoire/vector/bit_vector.rs
+++ b/src/grimoire/vector/bit_vector.rs
@@ -226,7 +226,7 @@ impl BitVector {
     /// # Errors
     ///
     /// Returns an error if reading fails or if num_1s > size.
-    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader<'_>) -> std::io::Result<()> {
         // Read units
         self.units.read(reader)?;
 

--- a/src/grimoire/vector/flat_vector.rs
+++ b/src/grimoire/vector/flat_vector.rs
@@ -194,7 +194,7 @@ impl FlatVector {
     /// # Errors
     ///
     /// Returns an error if reading fails or if value_size > 32.
-    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader<'_>) -> std::io::Result<()> {
         // Read units
         self.units.read(reader)?;
 

--- a/src/grimoire/vector/vector.rs
+++ b/src/grimoire/vector/vector.rs
@@ -234,7 +234,7 @@ impl<T: Copy> Vector<T> {
     /// # Errors
     ///
     /// Returns an error if reading fails.
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         // Read the total size (u64)
         let total_size: u64 = reader.read()?;
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -160,7 +160,7 @@ impl Trie {
     /// # Errors
     ///
     /// Returns an error if reading fails
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         let mut temp = Box::new(LoudsTrie::new());
         temp.read(reader)?;
         self.trie = Some(temp);


### PR DESCRIPTION
Currently, `Reader::from_reader` forces the generic reader R to have a `'static` lifetime because `Box<dyn IoRead>` defaults to `Box<dyn IoRead + 'static>`.

This prevents users from using Reader in streaming scenarios where they only have a mutable reference to a stream (e.g., `&mut TcpStream` or `&mut File`) and need to retain ownership of the stream after the Reader is done with its specific tasks.

Changes made:
- Introduced a lifetime parameter `<'a>` to the Reader struct: reader: `Option<Box<dyn IoRead + 'a>>`.
- Updated `Reader::from_reader<R: IoRead + 'a>(reader: R)` to accept readers with non-'static lifetimes.
- Updated methods that own their data entirely (`Reader::open` and `Reader::from_bytes`) to return `Reader<'static>`, minimizing the impact on existing usages.
- Updated Default implementation and test cases to accommodate the new lifetime parameter.

Users can now safely pass a mutable borrow of a stream without giving up ownership:

```rust
use std::io::Read;

fn handle_stream<R: Read>(stream: &mut R) -> std::io::Result<()> {
    // We can now pass a mutable reference since `&mut R` implements `Read`
    // and it no longer requires the `'static` bound.
    let mut reader = Reader::from_reader(stream);
    
    let magic: u32 = reader.read()?;
    println!("Magic: {}", magic);
    
    // The `stream` is still available here after `reader` goes out of scope!
    Ok(())
}
```

This is a minor breaking change for function signatures that previously accepted &mut Reader (they will now need to specify &mut Reader<'_>), but it heavily increases the flexibility and idiomatic Rust usage of the grimoire::io module.

**Powered by Gemini-3.1-Pro via Copilot**