### PR TITLE
feat(io): allow Reader/Writer to accept non-'static Read/Write implementations

### DIFF
--- a/src/grimoire/io/reader.rs
+++ b/src/grimoire/io/reader.rs
@@ -15,12 +15,12 @@ use std::path::Path;
 ///
 /// Reader wraps a std::io::Read implementation and provides convenient
 /// methods for reading typed data and seeking forward.
-pub struct Reader {
+pub struct Reader<'a> {
     /// The underlying reader, boxed for trait object support.
-    reader: Option<Box<dyn IoRead>>,
+    reader: Option<Box<dyn IoRead + 'a>>,
 }
 
-impl Reader {
+impl<'a> Reader<'a> {
     /// Creates a new empty reader.
     pub fn new() -> Self {
         Reader { reader: None }
@@ -35,7 +35,7 @@ impl Reader {
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened.
-    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Reader<'static>> {
         let file = File::open(path)?;
         Ok(Reader {
             reader: Some(Box::new(file)),
@@ -47,7 +47,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `reader` - Any type implementing Read
-    pub fn from_reader<R: IoRead + 'static>(reader: R) -> Self {
+    pub fn from_reader<R: IoRead + 'a>(reader: R) -> Self {
         Reader {
             reader: Some(Box::new(reader)),
         }
@@ -58,7 +58,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `bytes` - Byte slice to read from
-    pub fn from_bytes(bytes: &[u8]) -> Self {
+    pub fn from_bytes(bytes: &[u8]) -> Reader<'static> {
         Reader {
             reader: Some(Box::new(io::Cursor::new(bytes.to_vec()))),
         }
@@ -199,7 +199,7 @@ impl Reader {
     }
 }
 
-impl Default for Reader {
+impl<'a> Default for Reader<'a> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/grimoire/io/writer.rs
+++ b/src/grimoire/io/writer.rs
@@ -15,14 +15,14 @@ use std::path::Path;
 ///
 /// Writer wraps a std::io::Write implementation and provides convenient
 /// methods for writing typed data and seeking forward with zero padding.
-pub struct Writer {
+pub struct Writer<'a> {
     /// The underlying writer, boxed for trait object support.
-    writer: Option<Box<dyn IoWrite>>,
+    writer: Option<Box<dyn IoWrite + 'a>>,
     /// Optional buffer for in-memory writing (for testing).
     buffer: Option<Vec<u8>>,
 }
 
-impl Writer {
+impl<'a> Writer<'a> {
     /// Creates a new empty writer.
     pub fn new() -> Self {
         Writer {
@@ -40,7 +40,7 @@ impl Writer {
     /// # Errors
     ///
     /// Returns an error if the file cannot be created.
-    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Writer<'static>> {
         let file = File::create(path)?;
         Ok(Writer {
             writer: Some(Box::new(file)),
@@ -53,7 +53,7 @@ impl Writer {
     /// # Arguments
     ///
     /// * `writer` - Any type implementing Write
-    pub fn from_writer<W: IoWrite + 'static>(writer: W) -> Self {
+    pub fn from_writer<W: IoWrite + 'a>(writer: W) -> Self {
         Writer {
             writer: Some(Box::new(writer)),
             buffer: None,
@@ -61,7 +61,7 @@ impl Writer {
     }
 
     /// Creates a writer that writes to a `Vec<u8>`.
-    pub fn from_vec(vec: Vec<u8>) -> Self {
+    pub fn from_vec(vec: Vec<u8>) -> Writer<'static> {
         Writer {
             writer: None,
             buffer: Some(vec),
@@ -205,7 +205,7 @@ impl Writer {
     }
 }
 
-impl Default for Writer {
+impl<'a> Default for Writer<'a> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/grimoire/trie/header.rs
+++ b/src/grimoire/trie/header.rs
@@ -82,7 +82,7 @@ impl Header {
     /// # Errors
     ///
     /// Returns an error if the header is invalid or reading fails
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         let mut buf = [0u8; HEADER_SIZE];
         reader.read_slice(&mut buf)?;
 
@@ -105,7 +105,7 @@ impl Header {
     /// # Errors
     ///
     /// Returns an error if writing fails
-    pub fn write(&self, writer: &mut Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut Writer<'_>) -> std::io::Result<()> {
         writer.write_slice(Self::get_header())
     }
 

--- a/src/grimoire/trie/louds_trie.rs
+++ b/src/grimoire/trie/louds_trie.rs
@@ -936,7 +936,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if reading fails or header is invalid
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         use crate::grimoire::trie::header::Header;
         Header::new().read(reader)?;
         self.read_internal(reader)
@@ -951,7 +951,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if writing fails
-    pub fn write(&self, writer: &mut Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut Writer<'_>) -> std::io::Result<()> {
         use crate::grimoire::trie::header::Header;
         Header::new().write(writer)?;
         self.write_internal(writer)
@@ -978,7 +978,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if reading fails
-    fn read_internal(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    fn read_internal(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         // Read all component data structures
         self.louds.read(reader)?;
         self.terminal_flags.read(reader)?;
@@ -1030,7 +1030,7 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if writing fails
-    fn write_internal(&self, writer: &mut Writer) -> std::io::Result<()> {
+    fn write_internal(&self, writer: &mut Writer<'_>) -> std::io::Result<()> {
         // Write all component data structures
         self.louds.write(writer)?;
         self.terminal_flags.write(writer)?;

--- a/src/grimoire/trie/tail.rs
+++ b/src/grimoire/trie/tail.rs
@@ -258,7 +258,7 @@ impl Tail {
     /// # Errors
     ///
     /// Returns an error if reading fails.
-    pub fn read(&mut self, reader: &mut Reader) -> io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> io::Result<()> {
         self.buf.read(reader)?;
         self.end_flags.read(reader)?;
         Ok(())
@@ -277,7 +277,7 @@ impl Tail {
     /// # Errors
     ///
     /// Returns an error if writing fails.
-    pub fn write(&self, writer: &mut Writer) -> io::Result<()> {
+    pub fn write(&self, writer: &mut Writer<'_>) -> io::Result<()> {
         self.buf.write(writer)?;
         self.end_flags.write(writer)?;
         Ok(())

--- a/src/grimoire/vector/bit_vector.rs
+++ b/src/grimoire/vector/bit_vector.rs
@@ -226,7 +226,7 @@ impl BitVector {
     /// # Errors
     ///
     /// Returns an error if reading fails or if num_1s > size.
-    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader<'_>) -> std::io::Result<()> {
         // Read units
         self.units.read(reader)?;
 
@@ -269,7 +269,7 @@ impl BitVector {
     /// # Errors
     ///
     /// Returns an error if writing fails.
-    pub fn write(&self, writer: &mut crate::grimoire::io::Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut crate::grimoire::io::Writer<'_>) -> std::io::Result<()> {
         // Write units
         self.units.write(writer)?;
 

--- a/src/grimoire/vector/flat_vector.rs
+++ b/src/grimoire/vector/flat_vector.rs
@@ -194,7 +194,7 @@ impl FlatVector {
     /// # Errors
     ///
     /// Returns an error if reading fails or if value_size > 32.
-    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut crate::grimoire::io::Reader<'_>) -> std::io::Result<()> {
         // Read units
         self.units.read(reader)?;
 
@@ -234,7 +234,7 @@ impl FlatVector {
     /// # Errors
     ///
     /// Returns an error if writing fails.
-    pub fn write(&self, writer: &mut crate::grimoire::io::Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut crate::grimoire::io::Writer<'_>) -> std::io::Result<()> {
         // Write units
         self.units.write(writer)?;
 

--- a/src/grimoire/vector/vector.rs
+++ b/src/grimoire/vector/vector.rs
@@ -234,7 +234,7 @@ impl<T: Copy> Vector<T> {
     /// # Errors
     ///
     /// Returns an error if reading fails.
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         // Read the total size (u64)
         let total_size: u64 = reader.read()?;
 
@@ -281,7 +281,7 @@ impl<T: Copy> Vector<T> {
     /// # Errors
     ///
     /// Returns an error if writing fails.
-    pub fn write(&self, writer: &mut Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut Writer<'_>) -> std::io::Result<()> {
         // Write total size as u64
         let total = self.total_size() as u64;
         writer.write(&total)?;

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -160,7 +160,7 @@ impl Trie {
     /// # Errors
     ///
     /// Returns an error if reading fails
-    pub fn read(&mut self, reader: &mut Reader) -> std::io::Result<()> {
+    pub fn read(&mut self, reader: &mut Reader<'_>) -> std::io::Result<()> {
         let mut temp = Box::new(LoudsTrie::new());
         temp.read(reader)?;
         self.trie = Some(temp);
@@ -196,7 +196,7 @@ impl Trie {
     /// # Errors
     ///
     /// Returns an error if writing fails or trie is empty
-    pub fn write(&self, writer: &mut Writer) -> std::io::Result<()> {
+    pub fn write(&self, writer: &mut Writer<'_>) -> std::io::Result<()> {
         match self.trie.as_ref() {
             Some(trie) => trie.write(writer),
             None => Err(std::io::Error::new(


### PR DESCRIPTION
Currently, `Reader::from_reader`/`Writer::from_writer` forces the generic reader `R` and generic writer `W` to have a `'static` lifetime because `Box<dyn IoRead>`/`Box<dyn IoWrite>` defaults to `Box<dyn IoRead + 'static>`/`Box<dyn IoWrite + 'static>`.

This prevents users from using Reader/Write in streaming scenarios where they only have a mutable reference to a stream (e.g., `&mut TcpStream` or `&mut File`) and need to retain ownership of the stream after the Reader/Writer is done with its specific tasks.

Changes made:
- Introduced a lifetime parameter `<'a>` to the Reader and Writer struct: `reader: Option<Box<dyn IoRead + 'a>>` / `writer: Option<Box<dyn IoWrite + 'a>>`.
- Updated `Reader::from_reader<R: IoRead + 'a>(reader: R)`/  `Writer::from_writer<W: IoWrite + 'a>(writer: W)`to accept readers / writers with non-'static lifetimes.
- Updated methods that own their data entirely (`open` and `from_bytes`/ `from_vec`) to return `Reader<'static>` / `Writer<'static>`, minimizing the impact on existing usages.
- Updated Default implementation and test cases to accommodate the new lifetime parameter.

Users can now safely pass a mutable borrow of a stream without giving up ownership:

```rust
use std::io::Read;

fn handle_stream<R: Read>(stream: &mut R) -> std::io::Result<()> {
    // We can now pass a mutable reference since `&mut R` implements `Read`
    // and it no longer requires the `'static` bound.
    let mut reader = Reader::from_reader(stream);
    
    let magic: u32 = reader.read()?;
    println!("Magic: {}", magic);
    
    // The `stream` is still available here after `reader` goes out of scope!
    Ok(())
}
```

This is a minor breaking change for function signatures that previously accepted `&mut Reader` / `&mut Writer` (they will now need to specify `&mut Reader<'_>` / `&mut Writer<'_>` ), but it heavily increases the flexibility and idiomatic Rust usage of the `grimoire::io` module.

**Powered by Gemini-3.1-Pro via Copilot**