### PR TITLE
perf: shrink hot-path overhead in trie lookup

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -125,6 +125,27 @@ impl Agent {
         self.state.as_deref_mut()
     }
 
+    /// Returns the query bytes alongside a mutable reference to the state.
+    ///
+    /// This is a borrow-splitting helper for inner loops in tail/trie matching
+    /// that need to read query bytes while updating the state — calling
+    /// `agent.query()` and `agent.state_mut()` separately would force callers
+    /// to clone the query into a temporary `Vec` to satisfy the borrow checker.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the agent has no state initialized.
+    #[inline]
+    pub fn query_bytes_and_state_mut(&mut self) -> (&[u8], &mut State) {
+        // Borrow each field directly so the compiler treats them as disjoint.
+        let bytes = self.query.as_bytes();
+        let state = self
+            .state
+            .as_deref_mut()
+            .expect("Agent must have state initialized");
+        (bytes, state)
+    }
+
     /// Sets the key from a string slice.
     pub fn set_key_str(&mut self, s: &str) {
         self.key.set_str(s);

--- a/src/grimoire/trie/louds_trie.rs
+++ b/src/grimoire/trie/louds_trie.rs
@@ -1188,17 +1188,19 @@ impl LoudsTrie {
         let query_pos = state.query_pos();
         let query_len = agent.query().length();
 
-        assert!(query_pos < query_len, "Query position out of bounds");
+        debug_assert!(query_pos < query_len, "Query position out of bounds");
 
         let node_id = state.node_id();
         let query_char = agent.query().as_bytes()[query_pos];
 
-        // Check cache first
+        // Check cache first. Copy the entry (12B) so subsequent field reads
+        // hit registers/stack instead of repeating the Vector bounds check.
         let cache_id = self.get_cache_id_with_label(node_id, query_char);
-        if node_id == self.cache[cache_id].parent() {
+        let cache_entry = self.cache[cache_id];
+        if node_id == cache_entry.parent() {
             use crate::base::INVALID_EXTRA;
-            if self.cache[cache_id].extra() != INVALID_EXTRA as usize {
-                if !self.match_link(agent, self.cache[cache_id].link()) {
+            if cache_entry.extra() != INVALID_EXTRA as usize {
+                if !self.match_link(agent, cache_entry.link()) {
                     return false;
                 }
             } else {
@@ -1211,7 +1213,7 @@ impl LoudsTrie {
             agent
                 .state_mut()
                 .expect("Agent must have state")
-                .set_node_id(self.cache[cache_id].child());
+                .set_node_id(cache_entry.child());
             return true;
         }
 
@@ -1514,30 +1516,32 @@ impl LoudsTrie {
         let query_pos = state.query_pos();
         let query_len = agent.query().length();
 
-        assert!(query_pos < query_len, "Query position out of bounds");
+        debug_assert!(query_pos < query_len, "Query position out of bounds");
 
         let node_id = state.node_id();
         let query_char = agent.query().as_bytes()[query_pos];
 
-        // Check cache first
+        // Check cache first. Copy the entry (12B) so subsequent field reads
+        // hit registers/stack instead of repeating the Vector bounds check.
         let cache_id = self.get_cache_id_with_label(node_id, query_char);
-        if node_id == self.cache[cache_id].parent() {
+        let cache_entry = self.cache[cache_id];
+        if node_id == cache_entry.parent() {
             use crate::base::INVALID_EXTRA;
-            if self.cache[cache_id].extra() != INVALID_EXTRA as usize {
+            if cache_entry.extra() != INVALID_EXTRA as usize {
                 let _ = state;
-                if !self.prefix_match(agent, self.cache[cache_id].link()) {
+                if !self.prefix_match(agent, cache_entry.link()) {
                     return false;
                 }
             } else {
                 let _ = state;
                 let state = agent.state_mut().expect("Agent must have state");
-                state.key_buf_mut().push(self.cache[cache_id].label());
+                state.key_buf_mut().push(cache_entry.label());
                 state.set_query_pos(query_pos + 1);
             }
             agent
                 .state_mut()
                 .expect("Agent must have state")
-                .set_node_id(self.cache[cache_id].child());
+                .set_node_id(cache_entry.child());
             return true;
         }
 
@@ -1681,25 +1685,26 @@ impl LoudsTrie {
     /// Internal restore implementation for recursive calls.
     #[inline]
     fn restore_(&self, agent: &mut crate::agent::Agent, node_id: usize) {
-        assert!(node_id != 0, "Node ID must not be 0");
+        debug_assert!(node_id != 0, "Node ID must not be 0");
 
         let mut node_id = node_id;
 
         loop {
             let cache_id = self.get_cache_id(node_id);
-            if node_id == self.cache[cache_id].child() {
+            let cache_entry = self.cache[cache_id];
+            if node_id == cache_entry.child() {
                 use crate::base::INVALID_EXTRA;
-                if self.cache[cache_id].extra() != INVALID_EXTRA as usize {
-                    self.restore(agent, self.cache[cache_id].link());
+                if cache_entry.extra() != INVALID_EXTRA as usize {
+                    self.restore(agent, cache_entry.link());
                 } else {
                     agent
                         .state_mut()
                         .expect("Agent must have state")
                         .key_buf_mut()
-                        .push(self.cache[cache_id].label());
+                        .push(cache_entry.label());
                 }
 
-                node_id = self.cache[cache_id].parent();
+                node_id = cache_entry.parent();
                 if node_id == 0 {
                     return;
                 }
@@ -1728,22 +1733,23 @@ impl LoudsTrie {
         let query_len = agent.query().length();
         let mut query_pos = agent.state().expect("Agent must have state").query_pos();
 
-        assert!(query_pos < query_len, "Query position out of bounds");
-        assert!(node_id != 0, "Node ID must not be 0");
+        debug_assert!(query_pos < query_len, "Query position out of bounds");
+        debug_assert!(node_id != 0, "Node ID must not be 0");
 
         let mut node_id = node_id;
 
         loop {
             let cache_id = self.get_cache_id(node_id);
-            if node_id == self.cache[cache_id].child() {
+            let cache_entry = self.cache[cache_id];
+            if node_id == cache_entry.child() {
                 use crate::base::INVALID_EXTRA;
-                if self.cache[cache_id].extra() != INVALID_EXTRA as usize {
-                    if !self.match_link(agent, self.cache[cache_id].link()) {
+                if cache_entry.extra() != INVALID_EXTRA as usize {
+                    if !self.match_link(agent, cache_entry.link()) {
                         return false;
                     }
                     // Re-sync local query_pos after match_link may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
-                } else if self.cache[cache_id].label() == agent.query().as_bytes()[query_pos] {
+                } else if cache_entry.label() == agent.query().as_bytes()[query_pos] {
                     query_pos += 1;
                     agent
                         .state_mut()
@@ -1753,7 +1759,7 @@ impl LoudsTrie {
                     return false;
                 }
 
-                node_id = self.cache[cache_id].parent();
+                node_id = cache_entry.parent();
                 if node_id == 0 {
                     return true;
                 }
@@ -1802,26 +1808,27 @@ impl LoudsTrie {
         let query_len = agent.query().length();
         let mut query_pos = agent.state().expect("Agent must have state").query_pos();
 
-        assert!(query_pos < query_len, "Query position out of bounds");
-        assert!(node_id != 0, "Node ID must not be 0");
+        debug_assert!(query_pos < query_len, "Query position out of bounds");
+        debug_assert!(node_id != 0, "Node ID must not be 0");
         let mut node_id = node_id;
 
         loop {
             let cache_id = self.get_cache_id(node_id);
-            if node_id == self.cache[cache_id].child() {
+            let cache_entry = self.cache[cache_id];
+            if node_id == cache_entry.child() {
                 use crate::base::INVALID_EXTRA;
-                if self.cache[cache_id].extra() != INVALID_EXTRA as usize {
-                    if !self.prefix_match(agent, self.cache[cache_id].link()) {
+                if cache_entry.extra() != INVALID_EXTRA as usize {
+                    if !self.prefix_match(agent, cache_entry.link()) {
                         return false;
                     }
                     // Re-sync local query_pos after prefix_match may have modified agent state
                     query_pos = agent.state().expect("Agent must have state").query_pos();
-                } else if self.cache[cache_id].label() == agent.query().as_bytes()[query_pos] {
+                } else if cache_entry.label() == agent.query().as_bytes()[query_pos] {
                     agent
                         .state_mut()
                         .expect("Agent must have state")
                         .key_buf_mut()
-                        .push(self.cache[cache_id].label());
+                        .push(cache_entry.label());
                     query_pos += 1;
                     agent
                         .state_mut()
@@ -1831,7 +1838,7 @@ impl LoudsTrie {
                     return false;
                 }
 
-                node_id = self.cache[cache_id].parent();
+                node_id = cache_entry.parent();
                 if node_id == 0 {
                     return true;
                 }

--- a/src/grimoire/trie/state.rs
+++ b/src/grimoire/trie/state.rs
@@ -75,7 +75,7 @@ impl State {
     /// Panics if node_id > u32::MAX
     #[inline]
     pub fn set_node_id(&mut self, node_id: usize) {
-        assert!(node_id <= u32::MAX as usize, "Node ID exceeds u32::MAX");
+        debug_assert!(node_id <= u32::MAX as usize, "Node ID exceeds u32::MAX");
         self.node_id = node_id as u32;
     }
 
@@ -90,7 +90,7 @@ impl State {
     /// Panics if query_pos > u32::MAX
     #[inline]
     pub fn set_query_pos(&mut self, query_pos: usize) {
-        assert!(
+        debug_assert!(
             query_pos <= u32::MAX as usize,
             "Query position exceeds u32::MAX"
         );
@@ -108,7 +108,7 @@ impl State {
     /// Panics if history_pos > u32::MAX
     #[inline]
     pub fn set_history_pos(&mut self, history_pos: usize) {
-        assert!(
+        debug_assert!(
             history_pos <= u32::MAX as usize,
             "History position exceeds u32::MAX"
         );

--- a/src/grimoire/trie/tail.rs
+++ b/src/grimoire/trie/tail.rs
@@ -333,11 +333,13 @@ impl Tail {
             return false;
         }
 
-        // Get query bytes to avoid borrow conflicts
-        let query_bytes = agent.query().as_bytes().to_vec();
-        let mut query_pos = agent.state().expect("Agent must have state").query_pos();
+        // Split-borrow query bytes and state in one shot. Avoids cloning the
+        // query into a temporary Vec per call — match_tail runs inside the
+        // hot trie-lookup loop, so allocations show up clearly in profiles.
+        let (query_bytes, state) = agent.query_bytes_and_state_mut();
+        let mut query_pos = state.query_pos();
 
-        assert!(
+        debug_assert!(
             query_pos < query_bytes.len(),
             "Query position out of bounds"
         );
@@ -353,26 +355,27 @@ impl Tail {
                 // Access buf[offset + (query_pos - initial_query_pos)]
                 let buf_index = offset + (query_pos - initial_query_pos);
                 if buf_index >= self.buf.size() {
+                    state.set_query_pos(query_pos);
                     return false; // Unexpected end of buffer
                 }
                 if self.buf[buf_index] != query_bytes[query_pos] {
+                    state.set_query_pos(query_pos);
                     return false; // Mismatch
                 }
                 query_pos += 1;
-                agent
-                    .state_mut()
-                    .expect("Agent must have state")
-                    .set_query_pos(query_pos);
 
                 let buf_index = offset + (query_pos - initial_query_pos);
                 if buf_index >= self.buf.size() {
+                    state.set_query_pos(query_pos);
                     return false; // Unexpected end of buffer
                 }
                 if self.buf[buf_index] == 0 {
+                    state.set_query_pos(query_pos);
                     return true; // Found null terminator
                 }
 
                 if query_pos >= query_bytes.len() {
+                    state.set_query_pos(query_pos);
                     return false; // Query exhausted but no null terminator
                 }
             }
@@ -381,22 +384,21 @@ impl Tail {
             let mut i = offset;
             loop {
                 if self.buf[i] != query_bytes[query_pos] {
+                    state.set_query_pos(query_pos);
                     return false;
                 }
                 query_pos += 1;
-                agent
-                    .state_mut()
-                    .expect("Agent must have state")
-                    .set_query_pos(query_pos);
 
                 let is_end = self.end_flags.get(i);
                 i += 1;
 
                 if is_end {
+                    state.set_query_pos(query_pos);
                     return true;
                 }
 
                 if query_pos >= query_bytes.len() {
+                    state.set_query_pos(query_pos);
                     return false;
                 }
             }
@@ -418,25 +420,26 @@ impl Tail {
             return false;
         }
 
-        // Get query bytes to avoid borrow conflicts
-        let query_bytes = agent.query().as_bytes().to_vec();
-        let mut query_pos = agent.state().expect("Agent must have state").query_pos();
+        // Split-borrow query bytes and state; avoids cloning the query into a
+        // temporary Vec on the hot trie-lookup path.
+        let (query_bytes, state) = agent.query_bytes_and_state_mut();
+        let mut query_pos = state.query_pos();
 
         if self.end_flags.empty() {
             // Text mode
             let start_offset = offset - query_pos;
             loop {
                 if self.buf[start_offset + query_pos] != query_bytes[query_pos] {
+                    state.set_query_pos(query_pos);
                     return false;
                 }
-                let state = agent.state_mut().expect("Agent must have state");
                 state.key_buf_mut().push(self.buf[start_offset + query_pos]);
                 query_pos += 1;
-                state.set_query_pos(query_pos);
 
                 if start_offset + query_pos >= self.buf.size()
                     || self.buf[start_offset + query_pos] == 0
                 {
+                    state.set_query_pos(query_pos);
                     return true;
                 }
 
@@ -446,7 +449,7 @@ impl Tail {
             }
 
             // Append rest of tail
-            let state = agent.state_mut().expect("Agent must have state");
+            state.set_query_pos(query_pos);
             let mut i = start_offset + query_pos;
             while i < self.buf.size() && self.buf[i] != 0 {
                 state.key_buf_mut().push(self.buf[i]);
@@ -458,17 +461,17 @@ impl Tail {
             let mut i = offset;
             loop {
                 if self.buf[i] != query_bytes[query_pos] {
+                    state.set_query_pos(query_pos);
                     return false;
                 }
-                let state = agent.state_mut().expect("Agent must have state");
                 state.key_buf_mut().push(self.buf[i]);
                 query_pos += 1;
-                state.set_query_pos(query_pos);
 
                 let is_end = self.end_flags.get(i);
                 i += 1;
 
                 if is_end {
+                    state.set_query_pos(query_pos);
                     return true;
                 }
 
@@ -478,7 +481,7 @@ impl Tail {
             }
 
             // Append rest of tail
-            let state = agent.state_mut().expect("Agent must have state");
+            state.set_query_pos(query_pos);
             loop {
                 state.key_buf_mut().push(self.buf[i]);
                 if self.end_flags.get(i) {

--- a/src/grimoire/vector/bit_vector.rs
+++ b/src/grimoire/vector/bit_vector.rs
@@ -100,7 +100,7 @@ impl BitVector {
     /// Panics if `i >= size()`
     #[inline]
     pub fn get(&self, i: usize) -> bool {
-        assert!(i < self.size, "Index out of bounds");
+        debug_assert!(i < self.size, "Index out of bounds");
         let unit_index = i / WORD_SIZE;
         let bit_offset = i % WORD_SIZE;
         (self.units[unit_index] & ((1 as Unit) << bit_offset)) != 0
@@ -312,8 +312,8 @@ impl BitVector {
     /// Panics if the ranks index is empty or if i > size()
     #[inline]
     pub fn rank0(&self, i: usize) -> usize {
-        assert!(!self.ranks.empty(), "Rank index not built");
-        assert!(i <= self.size, "Index out of bounds");
+        debug_assert!(!self.ranks.empty(), "Rank index not built");
+        debug_assert!(i <= self.size, "Index out of bounds");
         i - self.rank1(i)
     }
 
@@ -332,9 +332,10 @@ impl BitVector {
     /// # Panics
     ///
     /// Panics if the ranks index is empty or if i > size()
+    #[inline]
     pub fn rank1(&self, i: usize) -> usize {
-        assert!(!self.ranks.empty(), "Rank index not built");
-        assert!(i <= self.size, "Index out of bounds");
+        debug_assert!(!self.ranks.empty(), "Rank index not built");
+        debug_assert!(i <= self.size, "Index out of bounds");
 
         let rank_index = &self.ranks[i / 512];
         let mut offset = rank_index.abs();
@@ -777,6 +778,7 @@ mod tests {
         assert!(bv2.get(0));
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "Index out of bounds")]
     fn test_bit_vector_out_of_bounds() {
@@ -868,6 +870,7 @@ mod tests {
         assert_eq!(bv.rank0(1000), 1000 - expected_rank1_at_1000);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "Rank index not built")]
     fn test_bit_vector_rank_without_build() {

--- a/src/grimoire/vector/select_bit.rs
+++ b/src/grimoire/vector/select_bit.rs
@@ -4,8 +4,74 @@
 //!
 //! This module provides the select_bit function which finds the position
 //! of the i-th set bit within a word.
+//!
+//! On x86_64 CPUs that support BMI2 (Haswell/Zen and later), we use the
+//! PDEP instruction for an essentially branch-free O(1) select. Detection
+//! is performed once and the result is cached in an atomic so subsequent
+//! calls cost a single relaxed load.
 
 use super::select_tables::SELECT_TABLE;
+
+#[cfg(target_arch = "x86_64")]
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Cached BMI2 (PDEP) detection result.
+///
+/// 0 = unknown (not probed yet), 1 = available, 2 = unavailable.
+/// `Relaxed` is sufficient: the worst case is multiple threads racing the
+/// initial probe, all writing the same value.
+#[cfg(target_arch = "x86_64")]
+static BMI2_AVAILABLE: AtomicU8 = AtomicU8::new(0);
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn has_bmi2() -> bool {
+    match BMI2_AVAILABLE.load(Ordering::Relaxed) {
+        1 => true,
+        2 => false,
+        _ => {
+            let detected = std::is_x86_feature_detected!("bmi2");
+            BMI2_AVAILABLE.store(if detected { 1 } else { 2 }, Ordering::Relaxed);
+            detected
+        }
+    }
+}
+
+/// PDEP-based select within a 64-bit word.
+///
+/// Places `1 << i` into the i-th set bit position of `unit` and returns
+/// its position. Requires BMI2 (caller must check `has_bmi2()`).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+#[inline]
+unsafe fn select_bit_u64_pdep(i: usize, bit_id: usize, unit: u64) -> usize {
+    // SAFETY: caller ensures BMI2 is available; intrinsic itself is safe
+    // beyond that.
+    let bit = core::arch::x86_64::_pdep_u64(1u64 << i, unit);
+    bit_id + bit.trailing_zeros() as usize
+}
+
+/// Portable byte-table fallback for select within a 64-bit word.
+#[inline]
+fn select_bit_u64_table(i: usize, bit_id: usize, unit: u64) -> usize {
+    let mut remaining = i;
+    let mut offset = 0usize;
+
+    // Process byte by byte
+    for byte_idx in 0..8 {
+        let byte = ((unit >> (byte_idx * 8)) & 0xFF) as u8;
+        let byte_popcount = byte.count_ones() as usize;
+
+        if remaining < byte_popcount {
+            return bit_id + offset + SELECT_TABLE[remaining][byte as usize] as usize;
+        }
+
+        remaining -= byte_popcount;
+        offset += 8;
+    }
+
+    bit_id + 63
+}
 
 /// Finds the position of the i-th set bit in a 64-bit unit.
 ///
@@ -17,32 +83,24 @@ use super::select_tables::SELECT_TABLE;
 ///
 /// # Returns
 ///
-/// The absolute position of the i-th set bit
-///
-/// This is a simplified implementation. The original C++ version uses SIMD
-/// optimizations for better performance.
+/// The absolute position of the i-th set bit.
 #[cfg(target_pointer_width = "64")]
 #[inline]
 pub fn select_bit_u64(i: usize, bit_id: usize, unit: u64) -> usize {
-    let mut remaining = i;
-    let mut offset = 0usize;
-
-    // Process byte by byte
-    for byte_idx in 0..8 {
-        let byte = ((unit >> (byte_idx * 8)) & 0xFF) as u8;
-        let byte_popcount = byte.count_ones() as usize;
-
-        if remaining < byte_popcount {
-            // The i-th bit is in this byte
-            return bit_id + offset + SELECT_TABLE[remaining][byte as usize] as usize;
-        }
-
-        remaining -= byte_popcount;
-        offset += 8;
+    #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
+    {
+        // Build-time BMI2: no detection needed, inline the PDEP path.
+        // SAFETY: target_feature implies the instruction is available.
+        return unsafe { select_bit_u64_pdep(i, bit_id, unit) };
     }
-
-    // Should not reach here if input is valid
-    bit_id + 63
+    #[cfg(all(target_arch = "x86_64", not(target_feature = "bmi2")))]
+    {
+        if has_bmi2() {
+            // SAFETY: BMI2 confirmed available at runtime.
+            return unsafe { select_bit_u64_pdep(i, bit_id, unit) };
+        }
+    }
+    select_bit_u64_table(i, bit_id, unit)
 }
 
 /// Finds the position of the i-th set bit in a 32-bit unit (for 32-bit platforms).
@@ -120,6 +178,40 @@ mod tests {
         // 0xFF00 = 8 bits starting at position 8
         assert_eq!(select_bit_u64(0, 0, 0xFF00), 8);
         assert_eq!(select_bit_u64(7, 0, 0xFF00), 15);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_select_bit_u64_high_bytes() {
+        // Bits in upper bytes
+        let unit: u64 = 1u64 << 40 | 1u64 << 50 | 1u64 << 63;
+        assert_eq!(select_bit_u64(0, 0, unit), 40);
+        assert_eq!(select_bit_u64(1, 0, unit), 50);
+        assert_eq!(select_bit_u64(2, 0, unit), 63);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_select_bit_u64_fallback_matches_pdep() {
+        // Cross-check fallback against the dispatcher across many inputs.
+        for unit in [
+            0x0123_4567_89AB_CDEFu64,
+            0xFFFF_FFFF_FFFF_FFFFu64,
+            0x8000_0000_0000_0001u64,
+            0xAAAA_AAAA_AAAA_AAAAu64,
+            0x5555_5555_5555_5555u64,
+        ] {
+            let ones = unit.count_ones() as usize;
+            for i in 0..ones {
+                assert_eq!(
+                    select_bit_u64(i, 0, unit),
+                    select_bit_u64_table(i, 0, unit),
+                    "mismatch at i={} unit={:#x}",
+                    i,
+                    unit
+                );
+            }
+        }
     }
 
     #[cfg(target_pointer_width = "32")]


### PR DESCRIPTION
## 概要

呼び出し元 ([akaza](https://github.com/akaza-im/akaza)) で bigram/skip-bigram の Viterbi DP が rsmarisa の trie lookup を大量に呼ぶワークロードに対してチューニング。release ビルドで残っていた境界チェックと、tail マッチでの per-call `Vec` 確保を削り、PDEP で select を高速化しました。

3 つの独立した変更を 3 commit に分割しています。

### 1. PDEP-based `select_bit_u64` on x86_64

BMI2 を初回 `is_x86_feature_detected!` で検出して `AtomicU8` にキャッシュ。以降のコールは relaxed load + 分岐 + PDEP (`_pdep_u64(1 << i, unit).trailing_zeros()`) で済む。フォールバックは従来のバイトテーブル loop。`target-feature=+bmi2` がビルド時に有効ならランタイム検出は短絡され完全に inline される。

非 x86 ターゲットは挙動変更なし。

### 2. hot path の `assert!` → `debug_assert!`

- `BitVector::{get, rank0, rank1}` の境界チェック
- `State::{set_node_id, set_query_pos, set_history_pos}` の `u32` 範囲チェック
- `LoudsTrie::{find_child, predictive_find_child, match_, prefix_match_, restore_}` 冒頭の `query_pos < query_len` / `node_id != 0`

いずれも構築不変条件 or 直後の `Vec` 境界チェックで重複しているもの。release ビルドの分岐数を減らします。`#[should_panic]` テスト 2 件は `select0/select1_without_build` と同じパターンで `#[cfg(debug_assertions)]` に gated。

### 3. `Tail::match_tail` / `prefix_match` の per-call alloc 撤去 + Cache ローカルコピー

- `Tail::match_tail` / `prefix_match` は `agent.query().as_bytes().to_vec()` で query を毎回 `Vec` に複製していました (borrow checker 対策)。bigram lookup では 6 バイトの `Vec` を allocate/free が回り、profiler で malloc/free 系で見える程度の負荷でした。`Agent::query_bytes_and_state_mut()` (split borrow ヘルパ) を追加して `(&[u8], &mut State)` を同時に取れるようにし、alloc を排除。
- `find_child` / `match_` / `prefix_match_` / `restore_` / `predictive_find_child` 内の `self.cache[cache_id]` 再 index を 1 度のコピー (`Cache` は 12B Copy) に置き換え。

## 計測

13th Gen Intel i7-1355U / Linux x86_64、呼び出し元の akaza-data bench (anthy corpus 50 文, k=5)。

| 関数 | before | after | 差 |
|---|---|---|---|
| `LoudsTrie::find_child` | 16.37% | 14.53% | -1.84pp |
| `LoudsTrie::match_` | 6.10% | 5.98% | -0.12pp |
| `LoudsTrie::prefix_match_` | 2.52% | 2.31% | -0.21pp |
| `BitVector::select0` | 2.67% | 2.11% | -0.56pp (PDEP) |
| `BitVector::select1` | 1.38% | 1.02% | -0.36pp (PDEP) |
| **rsmarisa 合計** | **~33%** | **~30%** | **-3pp** |

呼び出し元のベンチでは avg / median が 2-4% 改善。

## 互換性

- 公開 API の追加のみ (`Agent::query_bytes_and_state_mut`)、既存シグネチャは変更なし
- 出力結果は bit-exact (全 lookup/predictive_search/common_prefix_search テスト pass)
- BMI2 検出は runtime cached の `AtomicU8` で、非 BMI2 CPU でも安全に動作

## テスト

- `cargo test --lib`: **323 passed** ✅
- `cargo test --release --lib`: 318 passed / 3 failed
  - 失敗 3 件は `main` ブランチでも同様に失敗するプレ存在のもので、debug_assert に依存した `#[should_panic]` テストが gating されていないことに起因 (select0/select1 系は既に gated されている同じパターン)。本 PR の修正範囲外