### PR TITLE
feat: add WASM support via optional mmap feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,23 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  wasm:
+    name: WASM build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Check WASM build (no default features, no mmap)
+        run: cargo check --lib --no-default-features --target wasm32-unknown-unknown
+
+      - name: Check WASM build (default features)
+        run: cargo check --lib --target wasm32-unknown-unknown
+
   binary-compat:
     name: Binary Compatibility with C++ marisa-trie
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- WASM support. `memmap2` is now an optional dependency behind the default-on
+  `mmap` feature; building with `--no-default-features` produces a crate with no
+  `memmap2` dependency that compiles for `wasm32`. Dictionaries built natively
+  (64-bit) are loaded on WASM via `Trie::map()` from a host-provided buffer, and
+  verified end-to-end under a WASI runtime. `Trie::mmap()` / `LoudsTrie::mmap()`
+  require the `mmap` feature. Builds on the WASM groundwork from @nyanrus's
+  exploration in #20.
+
 ### Fixed
 
 - Fixed the bit-vector word size at 64 bits on every target instead of following

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,20 @@ exclude = [
     "*.marisa",
 ]
 
+[features]
+default = ["mmap"]
+
+# Memory-mapped file I/O via memmap2. Enabled by default for native targets.
+# Disable it (`--no-default-features`) to build for targets without mmap, such
+# as WASM; dictionaries are then loaded from host-provided buffers via
+# `Trie::map()` instead of `Trie::mmap()`.
+mmap = ["dep:memmap2"]
+
 [dependencies]
 # Required for CLI tools (rsmarisa-*)
 clap = { version = "4.5", features = ["derive"] }
-# Memory-mapped file I/O
-memmap2 = "0.9"
+# Memory-mapped file I/O (gated behind the `mmap` feature; native only)
+memmap2 = { version = "0.9", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/grimoire/io/mapper.rs
+++ b/src/grimoire/io/mapper.rs
@@ -6,9 +6,26 @@
 //!
 //! Mapper provides read-only access to data through memory mapping.
 //! This implementation supports both file-backed memory mapping and borrowed memory.
+//!
+//! When the `mmap` feature is disabled (e.g., for WASM), only borrowed memory
+//! mode is available. File-backed memory mapping requires the `mmap` feature.
+//!
+//! ## WASM Usage
+//!
+//! On WASM targets, memory mapping is unavailable. Instead, load trie data
+//! from the host environment and pass it as a byte slice:
+//!
+//! - **Browser**: Fetch the `.marisa` file as `Uint8Array` via `fetch()`,
+//!   then pass the buffer into WASM → `Mapper::open_memory()`.
+//! - **WASI**: Read the file via WASI filesystem APIs into a `Vec<u8>`,
+//!   then use `Mapper::open_memory()`.
+//! - **Embedded (WAMR)**: The host copies trie data into WASM linear memory,
+//!   and the module accesses it via `Mapper::open_memory()`.
+//!
+//! See also: [WAMR host data sharing](https://bytecodealliance.github.io/wamr.dev/blog/the-wasm-host-sharing-data-basics/)
 
+#[cfg(feature = "mmap")]
 use memmap2::Mmap;
-use std::fs::File;
 use std::io;
 
 /// Mapper for memory-mapped data access.
@@ -17,10 +34,11 @@ use std::io;
 /// deserializing trie structures from memory or files.
 ///
 /// The mapper can work in two modes:
-/// - File-backed memory mapping using `memmap2::Mmap`
+/// - File-backed memory mapping using `memmap2::Mmap` (requires `mmap` feature)
 /// - Borrowed memory slices (for testing or in-memory data)
 pub struct Mapper {
-    /// File-backed memory map.
+    /// File-backed memory map (only available with `mmap` feature).
+    #[cfg(feature = "mmap")]
     mmap: Option<Mmap>,
     /// Borrowed memory reference (static lifetime for safety).
     borrowed: Option<&'static [u8]>,
@@ -38,6 +56,7 @@ impl Mapper {
     /// Creates a new empty mapper.
     pub fn new() -> Self {
         Mapper {
+            #[cfg(feature = "mmap")]
             mmap: None,
             borrowed: None,
             position: 0,
@@ -53,6 +72,7 @@ impl Mapper {
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened or mapped.
+    /// On WASM (without the `mmap` feature), always returns an error.
     ///
     /// # Safety
     ///
@@ -62,7 +82,9 @@ impl Mapper {
     ///
     /// The caller must ensure that the file is not modified during the lifetime
     /// of the Mapper. Files should be opened read-only.
+    #[cfg(feature = "mmap")]
     pub fn open_file(filename: &str) -> io::Result<Self> {
+        use std::fs::File;
         let file = File::open(filename)?;
         let mmap = unsafe { Mmap::map(&file)? };
         Ok(Mapper {
@@ -70,6 +92,19 @@ impl Mapper {
             borrowed: None,
             position: 0,
         })
+    }
+
+    /// Opens a mapper from a file.
+    ///
+    /// Without the `mmap` feature, file-backed mapping is not available.
+    /// Returns an error indicating mmap is not supported.
+    #[cfg(not(feature = "mmap"))]
+    pub fn open_file(filename: &str) -> io::Result<Self> {
+        let _ = filename;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "File-backed memory mapping requires the 'mmap' feature (not available on WASM)",
+        ))
     }
 
     /// Opens a mapper from a byte slice.
@@ -84,6 +119,7 @@ impl Mapper {
     /// the mapper and any structures that reference it.
     pub fn open_memory(data: &'static [u8]) -> Self {
         Mapper {
+            #[cfg(feature = "mmap")]
             mmap: None,
             borrowed: Some(data),
             position: 0,
@@ -108,11 +144,11 @@ impl Mapper {
     ///
     /// Returns the data from either the memory map or borrowed slice.
     fn data(&self) -> &[u8] {
-        self.mmap
-            .as_ref()
-            .map(|m| &m[..])
-            .or(self.borrowed)
-            .unwrap_or(&[])
+        #[cfg(feature = "mmap")]
+        if let Some(ref m) = self.mmap {
+            return &m[..];
+        }
+        self.borrowed.unwrap_or(&[])
     }
 
     /// Maps a single value of type T from the current position.
@@ -248,7 +284,11 @@ impl Mapper {
 
     /// Checks if the mapper is open.
     pub fn is_open(&self) -> bool {
-        self.mmap.is_some() || self.borrowed.is_some()
+        #[cfg(feature = "mmap")]
+        if self.mmap.is_some() {
+            return true;
+        }
+        self.borrowed.is_some()
     }
 
     /// Returns the current position.
@@ -263,13 +303,17 @@ impl Mapper {
 
     /// Closes the mapper.
     pub fn clear(&mut self) {
-        self.mmap = None;
+        #[cfg(feature = "mmap")]
+        {
+            self.mmap = None;
+        }
         self.borrowed = None;
         self.position = 0;
     }
 
     /// Swaps with another mapper.
     pub fn swap(&mut self, other: &mut Mapper) {
+        #[cfg(feature = "mmap")]
         std::mem::swap(&mut self.mmap, &mut other.mmap);
         std::mem::swap(&mut self.borrowed, &mut other.borrowed);
         std::mem::swap(&mut self.position, &mut other.position);
@@ -298,6 +342,7 @@ mod tests {
         assert_eq!(mapper.position(), 0);
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_mapper_open_file() {
         // Create a temporary file
@@ -314,6 +359,7 @@ mod tests {
         assert_eq!(mapper.position(), 0);
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_mapper_open_file_not_found() {
         let result = Mapper::open_file("/nonexistent/file.dat");
@@ -483,6 +529,7 @@ mod tests {
         assert!(!mapper.is_open());
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_mapper_file_mapping() {
         // Create a temporary file with some data

--- a/src/grimoire/trie/louds_trie.rs
+++ b/src/grimoire/trie/louds_trie.rs
@@ -49,6 +49,11 @@ pub struct LoudsTrie {
     /// Rust drops fields in declaration order (top to bottom), so placing
     /// this last ensures all data structures are dropped before the Mapper,
     /// preventing dangling references to mmap'd memory.
+    ///
+    /// Only file-backed `mmap()` needs to keep the Mapper alive, so this field
+    /// exists only with the `mmap` feature. `map()` borrows `&'static` data
+    /// that outlives the trie regardless.
+    #[cfg(feature = "mmap")]
     mapper: Option<Mapper>,
 }
 
@@ -73,6 +78,7 @@ impl LoudsTrie {
             cache_mask: 0,
             num_l1_nodes: 0,
             config: Config::new(),
+            #[cfg(feature = "mmap")]
             mapper: None,
         }
     }
@@ -865,6 +871,9 @@ impl LoudsTrie {
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened/mapped or data is invalid.
+    ///
+    /// Requires the `mmap` feature (enabled by default; unavailable on WASM).
+    #[cfg(feature = "mmap")]
     pub fn mmap(&mut self, filename: &str) -> std::io::Result<()> {
         let mut mapper = Mapper::open_file(filename)?;
         use crate::grimoire::trie::header::Header;

--- a/src/grimoire/vector/bit_vector.rs
+++ b/src/grimoire/vector/bit_vector.rs
@@ -21,7 +21,7 @@ use crate::base::WORD_SIZE;
 /// rank and select operations through index structures.
 #[derive(Default)]
 pub struct BitVector {
-    /// Storage for bits, packed into Units (u32 or u64 depending on platform).
+    /// Storage for bits, packed into 64-bit Units.
     units: Vector<Unit>,
     /// Number of bits currently stored.
     size: usize,
@@ -64,9 +64,9 @@ impl BitVector {
             "BitVector size cannot exceed u32::MAX"
         );
 
-        // Expand units if needed
+        // Expand units if needed (one 64-bit unit at a time)
         if self.size == WORD_SIZE * self.units.size() {
-            self.units.resize(self.units.size() + (64 / WORD_SIZE), 0);
+            self.units.resize(self.units.size() + 1, 0);
         }
 
         // Set the bit if true

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -100,6 +100,9 @@ impl Trie {
     /// let mut trie = Trie::new();
     /// trie.mmap("dictionary.marisa").unwrap();
     /// ```
+    ///
+    /// Requires the `mmap` feature (enabled by default; unavailable on WASM).
+    #[cfg(feature = "mmap")]
     pub fn mmap(&mut self, filename: &str) -> std::io::Result<()> {
         let mut temp = Box::new(LoudsTrie::new());
         temp.mmap(filename)?;
@@ -816,6 +819,7 @@ mod tests {
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_trie_mmap() {
         // Rust-specific: Test memory-mapped file loading
@@ -865,6 +869,7 @@ mod tests {
         assert!(!trie2.lookup(&mut agent));
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_trie_mmap_vs_load_equivalence() {
         // Rust-specific: Verify that mmap() and load() produce identical behavior
@@ -925,6 +930,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "mmap")]
     #[test]
     fn test_trie_mmap_file_not_found() {
         // Rust-specific: Test that mmap with non-existent file returns error


### PR DESCRIPTION
## What

Adds **WASM support** by making `memmap2` an optional dependency behind a default-on `mmap` feature. Stage 2 of the WASM work (stage 1 was #23, which fixed the bit-vector word size at 64 bits on all targets).

## Changes

- **`Cargo.toml`**: new `mmap` feature (in `default`); `memmap2` is now `optional`. Build for WASM with `--no-default-features` → no `memmap2` dependency.
- **`Mapper`**: the file-backed mmap path (`open_file`, the `mmap` field) is gated behind `mmap`. The borrowed-memory path (`open_memory`) is always available. Without the feature, `open_file` returns an `Unsupported` error.
- **`Trie::mmap` / `LoudsTrie::mmap`** and the `LoudsTrie::mapper` field are gated behind `mmap`. `Trie::map()` (borrowed `&'static` data) is the WASM loading path and is available on every target.
- **CI**: new `wasm` job that `cargo check`s the `wasm32-unknown-unknown` build in both feature configurations.

## Verification

- `cargo check --lib --target wasm32-unknown-unknown` — passes with **and** without default features (no warnings).
- Native: `clippy --all-targets -D warnings` clean; 323 tests (default) / 317 (`--no-default-features`) pass; output byte-identical (unchanged from #23).
- **End-to-end runtime check**: built a dictionary natively (64-bit) with ASCII + Japanese keys, embedded it, compiled an example to `wasm32-wasip1`, and ran it under a WASI runtime (Node `node:wasi`). All lookups returned the same key IDs as native `rsmarisa-lookup`, including the not-found case:

  ```
  PASS apple -> 6   PASS app -> 2   PASS さくら -> 5   PASS 世界 -> 1   PASS nope -> -1
  RESULT: ALL PASS
  ```

## Usage on WASM

```rust
// host fetches the .marisa bytes and hands them to WASM as &'static [u8]
let mut trie = rsmarisa::Trie::new();
trie.map(DICT_BYTES)?;   // no mmap needed
```

## Credit

The `Mapper` feature-gating is based on @nyanrus's WASM exploration in #20. Thank you! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)